### PR TITLE
Modified hard-coded directory path

### DIFF
--- a/linesOfCode.cfm
+++ b/linesOfCode.cfm
@@ -1,6 +1,6 @@
 
 <!--- List of directories that need to be scanned --->
-<cfset dirList = "test,test2">
+<cfset dirList = "../controllers,../layouts,../model,../views">
 
 <cfoutput>
 <cfset numdir = 1>
@@ -13,7 +13,6 @@
 <cfloop list="#dirList#" index="ind" delimiters=",">
 	
 	<!--- Get all files in the directory and all its subdirectories (via recurse="true") --->
-	<cfdirectory directory="C:\ColdFusion9\wwwroot\#ind#" name="DirFiles" action="list" recurse="true">
      
 	<!--- Loop over all files in a directory --->
     <cfloop query="DirFiles">

--- a/linesOfCode.cfm
+++ b/linesOfCode.cfm
@@ -1,4 +1,3 @@
-
 <!--- List of directories that need to be scanned --->
 <cfset dirList = "../controllers,../layouts,../model,../views">
 
@@ -13,6 +12,7 @@
 <cfloop list="#dirList#" index="ind" delimiters=",">
 	
 	<!--- Get all files in the directory and all its subdirectories (via recurse="true") --->
+	<cfdirectory directory="#expandPath( ind )#" name="DirFiles" action="list" recurse="true">
      
 	<!--- Loop over all files in a directory --->
     <cfloop query="DirFiles">


### PR DESCRIPTION
Modified the hard-coded directory path to use expandPath() instead.
Modified default dirList to indicate that paths are now relative to
where the script is located... in this case inside a directory with it's
own Application.cfc that resides inside a FW/1 app.
